### PR TITLE
Handle blank lines in files without sections

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -23,7 +23,7 @@ const parse = (text, _parsers, _opts) => {
       section = { type: "section", name, value: [], lineno };
 
       root.value.push(section);
-    } else if (line.trim().length === 0 && section) {
+    } else if (line.trim().length === 0) {
       section = null;
     } else {
       throw new Error(`Error parsing .ini on line ${lineno}:\n${line}`);

--- a/test/__snapshots__/format.test.js.snap
+++ b/test/__snapshots__/format.test.js.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`defaults 1`] = `
+exports[`no-sections: defaults 1`] = `
+"; last modified 1 April 2001 by John Doe
+name=John Doe
+organization=Acme Widgets Inc.
+; use IP address in case network name resolution is not working
+server=192.0.2.62
+port=143
+file=\\"payroll.dat\\"
+# this is another kind of comment
+"
+`;
+
+exports[`no-sections: with space around equals 1`] = `
+"; last modified 1 April 2001 by John Doe
+name = John Doe
+organization = Acme Widgets Inc.
+; use IP address in case network name resolution is not working
+server = 192.0.2.62
+port = 143
+file = \\"payroll.dat\\"
+# this is another kind of comment
+"
+`;
+
+exports[`with-sections: defaults 1`] = `
 "; last modified 1 April 2001 by John Doe
 
 [owner]
@@ -16,7 +40,7 @@ file=\\"payroll.dat\\"
 "
 `;
 
-exports[`with space around equals 1`] = `
+exports[`with-sections: with space around equals 1`] = `
 "; last modified 1 April 2001 by John Doe
 
 [owner]

--- a/test/fixtures/no-sections.ini
+++ b/test/fixtures/no-sections.ini
@@ -1,0 +1,12 @@
+; last modified 1 April 2001 by John Doe
+
+name=John Doe
+organization=Acme Widgets Inc.
+
+  ; use IP address in case network name resolution is not working
+server=192.0.2.62  
+
+port=143
+file=  "payroll.dat"
+
+# this is another kind of comment

--- a/test/fixtures/with-sections.ini
+++ b/test/fixtures/with-sections.ini
@@ -1,4 +1,5 @@
 ; last modified 1 April 2001 by John Doe
+
 [owner]
 name=John Doe
 organization=Acme Widgets Inc.

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -2,16 +2,24 @@ const fs = require("fs");
 const path = require("path");
 const prettier = require("prettier");
 
-const fixture = fs.readFileSync(path.join(__dirname, "./fixture.ini"), "utf-8");
+const fixtures = ["with-sections", "no-sections"];
 const format = (content, options) =>
   prettier.format(content, { parser: "ini", plugins: ["."], ...options });
 
-test("defaults", () => {
-  const formatted = format(fixture, { iniSpaceAroundEquals: false });
-  expect(formatted).toMatchSnapshot();
-});
+for (const fixtureFile of fixtures) {
+  const fixturePath = path.join(__dirname, "./fixtures/", fixtureFile + '.ini');
+  const fixture = fs.readFileSync(fixturePath, "utf-8");
 
-test("with space around equals", () => {
-  const formatted = format(fixture, { iniSpaceAroundEquals: true });
-  expect(formatted).toMatchSnapshot();
-});
+  describe(fixtureFile + ":", () => {
+    test("defaults", () => {
+      const formatted = format(fixture, { iniSpaceAroundEquals: false });
+      expect(formatted).toMatchSnapshot();
+    });
+
+    test("with space around equals", () => {
+      const formatted = format(fixture, { iniSpaceAroundEquals: true });
+      expect(formatted).toMatchSnapshot();
+    });
+  });
+}
+


### PR DESCRIPTION
Currently parsing fails if a newline is found in a file without sections:

**Fails:**

```ini
one = a

two = b

```

**Succeeds:**

```ini
one = a

two = b

[section]
three = c
```
